### PR TITLE
Fix ambiguity issues

### DIFF
--- a/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
+++ b/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
@@ -181,15 +181,15 @@ void loop() {
 
   const uint8_t data_items = 2U;
   Telemetry data[data_items] = {
-    { Float(), TEMPERATURE_KEY, 42.2 },
-    { Int(), HUMIDITY_KEY,    80 },
+    { TEMPERATURE_KEY, 42.2 },
+    { HUMIDITY_KEY,    80 },
   };
 
   /* For C++98 compiler, shipped with Arduino IDE version 1.6.6 or less:
 
   Telemetry data[data_items] = {
-    Telemetry( Float(), TEMPERATURE_KEY, 42.2 ),
-    Telemetry( Int(), HUMIDITY_KEY,    80 ),
+    Telemetry( TEMPERATURE_KEY, 42.2 ),
+    Telemetry( HUMIDITY_KEY,    80 ),
   };
 
   */
@@ -207,15 +207,15 @@ void loop() {
 
   const int attribute_items = 2;
   Attribute attributes[attribute_items] = {
-    { CString(), DEVICE_TYPE_KEY,  SENSOR_VALUE },
-    { Bool(), ACTIVE_KEY,       true     },
+    { DEVICE_TYPE_KEY,  SENSOR_VALUE },
+    { ACTIVE_KEY,       true     },
   };
 
   /* For C++98 compiler, shipped with Arduino IDE version 1.6.6 or less:
 
   Attribute attributes[data_items] = {
-    Attribute( CString(), DEVICE_TYPE_KEY,  SENSOR_VALUE ),
-    Attribute( Bool(), ACTIVE_KEY,       true     ),
+    Attribute( DEVICE_TYPE_KEY,  SENSOR_VALUE ),
+    Attribute( ACTIVE_KEY,       true     ),
   };
 
   */

--- a/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
+++ b/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
@@ -181,15 +181,15 @@ void loop() {
 
   const uint8_t data_items = 2U;
   Telemetry data[data_items] = {
-    { TEMPERATURE_KEY, 42.2 },
-    { HUMIDITY_KEY,    80 },
+    { Float(), TEMPERATURE_KEY, 42.2 },
+    { Int(), HUMIDITY_KEY,    80 },
   };
 
   /* For C++98 compiler, shipped with Arduino IDE version 1.6.6 or less:
 
   Telemetry data[data_items] = {
-    Telemetry( TEMPERATURE_KEY, 42.2 ),
-    Telemetry( HUMIDITY_KEY,    80 ),
+    Telemetry( Float(), TEMPERATURE_KEY, 42.2 ),
+    Telemetry( Int(), HUMIDITY_KEY,    80 ),
   };
 
   */

--- a/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
+++ b/examples/0001-arduino_send_batch/0001-arduino_send_batch.ino
@@ -207,15 +207,15 @@ void loop() {
 
   const int attribute_items = 2;
   Attribute attributes[attribute_items] = {
-    { DEVICE_TYPE_KEY,  SENSOR_VALUE },
-    { ACTIVE_KEY,       true     },
+    { CString(), DEVICE_TYPE_KEY,  SENSOR_VALUE },
+    { Bool(), ACTIVE_KEY,       true     },
   };
 
   /* For C++98 compiler, shipped with Arduino IDE version 1.6.6 or less:
 
   Attribute attributes[data_items] = {
-    Attribute( DEVICE_TYPE_KEY,  SENSOR_VALUE ),
-    Attribute( ACTIVE_KEY,       true     ),
+    Attribute( CString(), DEVICE_TYPE_KEY,  SENSOR_VALUE ),
+    Attribute( Bool(), ACTIVE_KEY,       true     ),
   };
 
   */

--- a/examples/0002-arduino_rpc/0002-arduino_rpc.ino
+++ b/examples/0002-arduino_rpc/0002-arduino_rpc.ino
@@ -178,7 +178,7 @@ RPC_Response processTemperatureChange(const RPC_Data &data) {
   // Just an response example
   StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
   doc[RPC_RESPONSE_KEY] = 42;
-  return doc;
+  return RPC_Response(doc);
 }
 
 /// @brief Processes function for RPC call "example_set_switch"
@@ -202,7 +202,7 @@ RPC_Response processSwitchChange(const RPC_Data &data) {
   // Just an response example
   StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
   doc[RPC_RESPONSE_KEY] = 22.02;
-  return doc;
+  return RPC_Response(doc);
 }
 
 const uint8_t callback_size = 2U;

--- a/examples/0010-esp8266_esp32_rpc/0010-esp8266_esp32_rpc.ino
+++ b/examples/0010-esp8266_esp32_rpc/0010-esp8266_esp32_rpc.ino
@@ -244,7 +244,7 @@ RPC_Response processTemperatureChange(const RPC_Data &data) {
   // Just an response example
   StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
   doc[RPC_RESPONSE_KEY] = 42;
-  return doc;
+  return RPC_Response(doc);
 }
 
 /// @brief Processes function for RPC call "example_set_switch"
@@ -272,7 +272,7 @@ RPC_Response processSwitchChange(const RPC_Data &data) {
   // Just an response example
   StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
   doc[RPC_RESPONSE_KEY] = 22.02;
-  return doc;
+  return RPC_Response(doc);
 }
 
 const std::array<RPC_Callback, 2U> callbacks = {

--- a/library.json
+++ b/library.json
@@ -7,7 +7,7 @@
         "url": "https://github.com/thingsboard/thingsboard-arduino-sdk"
     },
     "dependencies": {
-        "bblanchon/ArduinoJson": "^6.20.1",
+        "bblanchon/ArduinoJson": "^6.21.1",
         "thingsboard/TBPubSubClient": "https://github.com/thingsboard/pubsubclient.git#v2.9.1",
         "arduino-libraries/ArduinoHttpClient" : "^0.4.0"
     },

--- a/src/Attribute_Request_Callback.h
+++ b/src/Attribute_Request_Callback.h
@@ -7,9 +7,11 @@
 #ifndef Attribute_Request_Callback_h
 #define Attribute_Request_Callback_h
 
+// Local includes.
+#include "Configuration.h"
+
 // Library includes.
 #include <ArduinoJson.h>
-#include "Configuration.h"
 #if THINGSBOARD_ENABLE_STL
 #include <functional>
 #include <vector>

--- a/src/RPC_Callback.h
+++ b/src/RPC_Callback.h
@@ -9,8 +9,9 @@
 
 // Local includes.
 #include "Configuration.h"
-
 #include "RPC_Response.h"
+
+// Library includes.
 #if THINGSBOARD_ENABLE_STL
 #include <functional>
 #endif // THINGSBOARD_ENABLE_STL

--- a/src/RPC_Response.h
+++ b/src/RPC_Response.h
@@ -29,9 +29,9 @@ public:
         this->set(object);
     }
 
-    template <typename T1, typename T2>
-    RPC_Response(T1 type, const char *key, T2 value)
-      : RPC_Response(Telemetry(type, key, value)) {
+    template <typename T>
+    RPC_Response(const char *key, T value)
+      : RPC_Response(Telemetry(key, value)) {
     }
 };
 

--- a/src/RPC_Response.h
+++ b/src/RPC_Response.h
@@ -1,7 +1,9 @@
-//
-// Created by imbeacon on 07.04.23.
-//
-
+/*
+  RPC_Response.h - Library API for sending data to the ThingsBoard
+  Based on PubSub MQTT library.
+  Created by Olender M. Oct 2018.
+  Released into the public domain.
+*/
 #ifndef RPC_RESPONSE_H
 #define RPC_RESPONSE_H
 
@@ -10,19 +12,26 @@
 class RPC_Response : public JsonVariant {
 public:
 
-    RPC_Response() {
-        JsonVariant();
+    RPC_Response()
+      : JsonVariant() {
+    }
+
+    RPC_Response(JsonVariant variant)
+      : JsonVariant(variant) {
     }
 
     RPC_Response(Telemetry telemetry) {
-        StaticJsonDocument<JSON_OBJECT_SIZE(1)> doc;
-        telemetry.SerializeKeyValue(doc);
-        this->set(doc.as<JsonObject>());
+        StaticJsonDocument<JSON_OBJECT_SIZE(1)> jsonBuffer;
+        const JsonVariant object = jsonBuffer.to<JsonVariant>();
+        if (!telemetry.SerializeKeyValue(object)) {
+            return;
+        }
+        this->set(object);
     }
 
     template <typename T1, typename T2>
-    RPC_Response(T1 key, T2 value) {
-        RPC_Response(Telemetry(key, value));
+    RPC_Response(T1 key, T2 value)
+      : RPC_Response(Telemetry(key, value)) {
     }
 };
 

--- a/src/RPC_Response.h
+++ b/src/RPC_Response.h
@@ -30,8 +30,8 @@ public:
     }
 
     template <typename T1, typename T2>
-    RPC_Response(T1 key, T2 value)
-      : RPC_Response(Telemetry(key, value)) {
+    RPC_Response(T1 type, const char *key, T2 value)
+      : RPC_Response(Telemetry(type, key, value)) {
     }
 };
 

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -10,6 +10,13 @@
 // Library includes.
 #include <ArduinoJson.h>
 
+// Struct dispatch tags, to differentiate between constructors,
+// solves the issue of not being able to distuinguish float, integer and the boolean constructor.
+struct Float{};
+struct Bool{};
+struct Int{};
+struct String{};
+
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {
   public:
@@ -20,7 +27,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from integer value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(const char *key, int val)
+    inline Telemetry(Int, const char *key, int val)
             : m_type(DataType::TYPE_INT), m_key(key), m_value()   {
         m_value.integer = val;
     }
@@ -28,7 +35,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from boolean value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(const char *key, bool val)
+    inline Telemetry(Bool, const char *key, bool val)
             : m_type(DataType::TYPE_BOOL), m_key(key), m_value()  {
         m_value.boolean = val;
     }
@@ -36,7 +43,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from float value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(const char *key, float val)
+    inline Telemetry(Float, const char *key, float val)
       : m_type(DataType::TYPE_REAL), m_key(key), m_value()  {
       m_value.real = val;
     }
@@ -44,7 +51,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from string value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(const char *key, const char *val)
+    inline Telemetry(String, const char *key, const char *val)
             : m_type(DataType::TYPE_STR), m_key(key), m_value()   {
         m_value.str = val;
     }

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -9,7 +9,7 @@
 
 // Library includes.
 #include <ArduinoJson.h>
-#include <<concepts>
+#include <concepts>
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -7,9 +7,14 @@
 #ifndef Telemetry_h
 #define Telemetry_h
 
+// Local includes.
+#include "Configuration.h"
+
 // Library includes.
 #include <ArduinoJson.h>
+#if THINGSBOARD_ENABLE_STL
 #include <type_traits>
+#endif // THINGSBOARD_ENABLE_STL
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {
@@ -17,6 +22,8 @@ class Telemetry {
     /// @brief Creates an empty Telemetry record containg neither a key nor value
     inline Telemetry()
       : m_type(DataType::TYPE_NONE), m_key(NULL), m_value() { }
+
+#if THINGSBOARD_ENABLE_STL
 
     /// @brief Constructs telemetry record from integer value
     /// @brief Constructs telemetry record from integer value
@@ -26,10 +33,12 @@ class Telemetry {
     /// @param val Value of the key value pair we want to create
     template <typename T,
               typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-    inline Telemetry(const char *key, int val)
+    inline Telemetry(const char *key, T val)
             : m_type(DataType::TYPE_INT), m_key(key), m_value()   {
         m_value.integer = val;
     }
+
+#endif // THINGSBOARD_ENABLE_STL
 
     /// @brief Constructs telemetry record from boolean value
     /// @param key Key of the key value pair we want to create

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -9,6 +9,7 @@
 
 // Library includes.
 #include <ArduinoJson.h>
+#include <type_traits>
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -10,13 +10,6 @@
 // Library includes.
 #include <ArduinoJson.h>
 
-// Struct dispatch tags, to differentiate between constructors,
-// solves the issue of not being able to distuinguish float, integer and the boolean constructor.
-struct Float{};
-struct Bool{};
-struct Int{};
-struct CString{};
-
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {
   public:
@@ -25,9 +18,14 @@ class Telemetry {
       : m_type(DataType::TYPE_NONE), m_key(NULL), m_value() { }
 
     /// @brief Constructs telemetry record from integer value
+    /// @brief Constructs telemetry record from integer value
+    /// @tparam T Type of the passed value, is required to be integral,
+    /// to ensure this constructor isn't used instead of the float one by mistake
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(Int, const char *key, int val)
+    template <typename T,
+              typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+    inline Telemetry(const char *key, int val)
             : m_type(DataType::TYPE_INT), m_key(key), m_value()   {
         m_value.integer = val;
     }
@@ -35,7 +33,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from boolean value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(Bool, const char *key, bool val)
+    inline Telemetry(const char *key, bool val)
             : m_type(DataType::TYPE_BOOL), m_key(key), m_value()  {
         m_value.boolean = val;
     }
@@ -43,7 +41,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from float value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(Float, const char *key, float val)
+    inline Telemetry(const char *key, float val)
       : m_type(DataType::TYPE_REAL), m_key(key), m_value()  {
       m_value.real = val;
     }
@@ -51,7 +49,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from string value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(CString, const char *key, const char *val)
+    inline Telemetry(const char *key, const char *val)
             : m_type(DataType::TYPE_STR), m_key(key), m_value()   {
         m_value.str = val;
     }

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -15,7 +15,7 @@
 struct Float{};
 struct Bool{};
 struct Int{};
-struct String{};
+struct CString{};
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {
@@ -51,7 +51,7 @@ class Telemetry {
     /// @brief Constructs telemetry record from string value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(String, const char *key, const char *val)
+    inline Telemetry(CString, const char *key, const char *val)
             : m_type(DataType::TYPE_STR), m_key(key), m_value()   {
         m_value.str = val;
     }

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -9,7 +9,7 @@
 
 // Library includes.
 #include <ArduinoJson.h>
-#include <concepts>
+#include <type_traits>
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -9,7 +9,7 @@
 
 // Library includes.
 #include <ArduinoJson.h>
-#include <type_traits>
+#include <<concepts>
 
 /// @brief Telemetry record class, allows to store different data using a common interface.
 class Telemetry {

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -49,14 +49,6 @@ class Telemetry {
         m_value.str = val;
     }
 
-    /// @brief Constructs telemetry record from string value
-    /// @param key Key of the key value pair we want to create
-    /// @param val Value of the key value pair we want to create
-    inline Telemetry(const char *key, const char *val)
-            : m_type(DataType::TYPE_STR), m_key(key), m_value()   {
-        m_value.str = val;
-    }
-
     /// @brief Whether this record is empty or not
     /// @return Whether there is any data in this record or not
     inline bool IsEmpty() const {

--- a/src/Telemetry.h
+++ b/src/Telemetry.h
@@ -18,22 +18,10 @@ class Telemetry {
       : m_type(DataType::TYPE_NONE), m_key(NULL), m_value() { }
 
     /// @brief Constructs telemetry record from integer value
-    /// @tparam T Type of the passed value, is required to be integral,
-    /// to ensure this constructor isn't used instead of the float one by mistake
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
     inline Telemetry(const char *key, int val)
             : m_type(DataType::TYPE_INT), m_key(key), m_value()   {
-        m_value.integer = val;
-    }
-
-    /// @brief Constructs telemetry record from integer value
-    /// @tparam T Type of the passed value, is required to be integral,
-    /// to ensure this constructor isn't used instead of the float one by mistake
-    /// @param key Key of the key value pair we want to create
-    /// @param val Value of the key value pair we want to create
-    inline Telemetry(String key, int val)
-            : m_type(DataType::TYPE_INT), m_key(key.c_str()), m_value()   {
         m_value.integer = val;
     }
 
@@ -42,14 +30,6 @@ class Telemetry {
     /// @param val Value of the key value pair we want to create
     inline Telemetry(const char *key, bool val)
             : m_type(DataType::TYPE_BOOL), m_key(key), m_value()  {
-        m_value.boolean = val;
-    }
-
-    /// @brief Constructs telemetry record from boolean value
-    /// @param key Key of the key value pair we want to create
-    /// @param val Value of the key value pair we want to create
-    inline Telemetry(String key, bool val)
-            : m_type(DataType::TYPE_BOOL), m_key(key.c_str()), m_value()  {
         m_value.boolean = val;
     }
 
@@ -72,17 +52,9 @@ class Telemetry {
     /// @brief Constructs telemetry record from string value
     /// @param key Key of the key value pair we want to create
     /// @param val Value of the key value pair we want to create
-    inline Telemetry(String key, const char *val)
-            : m_type(DataType::TYPE_STR), m_key(key.c_str()), m_value()   {
+    inline Telemetry(const char *key, const char *val)
+            : m_type(DataType::TYPE_STR), m_key(key), m_value()   {
         m_value.str = val;
-    }
-
-    /// @brief Constructs telemetry record from string value
-    /// @param key Key of the key value pair we want to create
-    /// @param val Value of the key value pair we want to create
-    inline Telemetry(String key, String val)
-            : m_type(DataType::TYPE_STR), m_key(key.c_str()), m_value()   {
-        m_value.str = val.c_str();
     }
 
     /// @brief Whether this record is empty or not

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -637,14 +637,13 @@ class ThingsBoardSized {
     // Telemetry API
 
     /// @brief Attempts to send telemetry data with the given key and value of the given type
-    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
+    /// @tparam T Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    template<typename T1, typename T2>
-    inline bool sendTelemetryData(T1 type, const char *key, T2 value) {
-      return sendKeyValue(type, key, value);
+    template<typename T>
+    inline bool sendTelemetryData(const char *key, T2 value) {
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send integer telemetry data with the given key and value
@@ -652,7 +651,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryInt(const char *key, int value) {
-      return sendKeyValue(Int(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send boolean telemetry data with the given key and value
@@ -660,7 +659,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryBool(const char *key, bool value) {
-      return sendKeyValue(Bool(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send float telemetry data with the given key and value
@@ -668,7 +667,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryFloat(const char *key, float value) {
-      return sendKeyValue(Float(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send string telemetry data with the given key and value
@@ -676,7 +675,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryString(const char *key, const char *value) {
-      return sendKeyValue(CString(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data
@@ -812,13 +811,12 @@ class ThingsBoardSized {
     // Attribute API
 
     /// @brief Attempts to send attribute data with the given key and value of the given type
-    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
+    /// @tparam T Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    template<typename T1, typename T2>
-    inline bool sendAttributeData(T1 type, const char *key, T2 value) {
+    template<typename T>
+    inline bool sendAttributeData(const char *key, T value) {
       return sendKeyValue(key, value, false);
     }
 
@@ -827,7 +825,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeInt(const char *key, int value) {
-      return sendKeyValue(Int(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send boolean attribute data with the given key and value
@@ -835,7 +833,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeBool(const char *key, bool value) {
-      return sendKeyValue(Bool(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send float attribute data with the given key and value
@@ -843,7 +841,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeFloat(const char *key, float value) {
-      return sendKeyValue(Float(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send string attribute data with the given key and value
@@ -851,7 +849,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeString(const char *key, const char *value) {
-      return sendKeyValue(CString(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data
@@ -1847,15 +1845,14 @@ class ThingsBoardSized {
     }
 
     /// @brief Attempts to send a single key-value pair with the given key and value of the given type
-    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
+    /// @tparam T Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @param telemetry Whether the data we want to send should be sent as an attribute or telemetry data value
     /// @return Whether sending the data was successful or not
-    template<typename T1, typename T2>
-    inline bool sendKeyValue(T1 type, const char *key, T2 value, bool telemetry = true) {
-      const Telemetry t(type, key, value);
+    template<typename T>
+    inline bool sendKeyValue(const char *key, T value, bool telemetry = true) {
+      const Telemetry t(key, value);
       if (t.IsEmpty()) {
         // Message is ignored and not sent at all.
         return false;

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -642,7 +642,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     template<typename T>
-    inline bool sendTelemetryData(const char *key, T2 value) {
+    inline bool sendTelemetryData(const char *key, T value) {
       return sendKeyValue(key, value);
     }
 

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -637,13 +637,14 @@ class ThingsBoardSized {
     // Telemetry API
 
     /// @brief Attempts to send telemetry data with the given key and value of the given type
-    /// @tparam T Type of the data value we want to send
+    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    template<class T>
-    inline bool sendTelemetryData(const char *key, T value) {
-      return sendKeyValue(key, value);
+    template<typename T1, typename T2>
+    inline bool sendTelemetryData(T1 type, const char *key, T2 value) {
+      return sendKeyValue(type, key, value);
     }
 
     /// @brief Attempts to send integer telemetry data with the given key and value
@@ -651,7 +652,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryInt(const char *key, int value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(Int(), key, value);
     }
 
     /// @brief Attempts to send boolean telemetry data with the given key and value
@@ -659,7 +660,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryBool(const char *key, bool value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(Bool(), key, value);
     }
 
     /// @brief Attempts to send float telemetry data with the given key and value
@@ -667,7 +668,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryFloat(const char *key, float value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(Float(), key, value);
     }
 
     /// @brief Attempts to send string telemetry data with the given key and value
@@ -675,7 +676,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryString(const char *key, const char *value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(String(), key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data
@@ -811,45 +812,46 @@ class ThingsBoardSized {
     // Attribute API
 
     /// @brief Attempts to send attribute data with the given key and value of the given type
-    /// @tparam T Type of the data value we want to send
+    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    template<class T>
-    inline bool sendAttributeData(const char *attrName, T value) {
-      return sendKeyValue(attrName, value, false);
+    template<typename T1, typename T2>
+    inline bool sendAttributeData(T1 type, const char *key, T2 value) {
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send integer attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    inline bool sendAttributeInt(const char *attrName, int value) {
-      return sendKeyValue(attrName, value, false);
+    inline bool sendAttributeInt(const char *key, int value) {
+      return sendKeyValue(Int(), key, value, false);
     }
 
     /// @brief Attempts to send boolean attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    inline bool sendAttributeBool(const char *attrName, bool value) {
-      return sendKeyValue(attrName, value, false);
+    inline bool sendAttributeBool(const char *key, bool value) {
+      return sendKeyValue(Bool(), key, value, false);
     }
 
     /// @brief Attempts to send float attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    inline bool sendAttributeFloat(const char *attrName, float value) {
-      return sendKeyValue(attrName, value, false);
+    inline bool sendAttributeFloat(const char *key, float value) {
+      return sendKeyValue(Float(), key, value, false);
     }
 
     /// @brief Attempts to send string attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    inline bool sendAttributeString(const char *attrName, const char *value) {
-      return sendKeyValue(attrName, value, false);
+    inline bool sendAttributeString(const char *key, const char *value) {
+      return sendKeyValue(String(), key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data
@@ -1845,14 +1847,15 @@ class ThingsBoardSized {
     }
 
     /// @brief Attempts to send a single key-value pair with the given key and value of the given type
-    /// @tparam T Type of the data value we want to send
+    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @param telemetry Whether the data we want to send should be sent as an attribute or telemetry data value
     /// @return Whether sending the data was successful or not
-    template<typename T>
-    inline bool sendKeyValue(const char *key, T value, bool telemetry = true) {
-      const Telemetry t(key, value);
+    template<typename T1, typename T2>
+    inline bool sendKeyValue(T1 type, const char *key, T2 value, bool telemetry = true) {
+      const Telemetry t(type, key, value);
       if (t.IsEmpty()) {
         // Message is ignored and not sent at all.
         return false;

--- a/src/ThingsBoard.h
+++ b/src/ThingsBoard.h
@@ -638,7 +638,7 @@ class ThingsBoardSized {
 
     /// @brief Attempts to send telemetry data with the given key and value of the given type
     /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
@@ -676,7 +676,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryString(const char *key, const char *value) {
-      return sendKeyValue(String(), key, value);
+      return sendKeyValue(CString(), key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data
@@ -813,7 +813,7 @@ class ThingsBoardSized {
 
     /// @brief Attempts to send attribute data with the given key and value of the given type
     /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
@@ -851,7 +851,7 @@ class ThingsBoardSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeString(const char *key, const char *value) {
-      return sendKeyValue(String(), key, value, false);
+      return sendKeyValue(CString(), key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data
@@ -1848,7 +1848,7 @@ class ThingsBoardSized {
 
     /// @brief Attempts to send a single key-value pair with the given key and value of the given type
     /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @param telemetry Whether the data we want to send should be sent as an attribute or telemetry data value

--- a/src/ThingsBoardHttp.h
+++ b/src/ThingsBoardHttp.h
@@ -126,14 +126,13 @@ class ThingsBoardHttpSized {
     // Telemetry API
 
     /// @brief Attempts to send telemetry data with the given key and value of the given type
-    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
+    /// @tparam T Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    template<typename T1, typename T2>
-    inline bool sendTelemetryData(T1 type, const char *key, T2 value) {
-      return sendKeyValue(type, key, value);
+    template<typename T>
+    inline bool sendTelemetryData(const char *key, T value) {
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send integer telemetry data with the given key and value
@@ -141,7 +140,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryInt(const char *key, int value) {
-      return sendKeyValue(Int(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send boolean telemetry data with the given key and value
@@ -149,7 +148,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryBool(const char *key, bool value) {
-      return sendKeyValue(Bool(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send float telemetry data with the given key and value
@@ -157,7 +156,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryFloat(const char *key, float value) {
-      return sendKeyValue(Float(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send string telemetry data with the given key and value
@@ -165,7 +164,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryString(const char *key, const char *value) {
-      return sendKeyValue(CString(), key, value);
+      return sendKeyValue(key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data
@@ -310,13 +309,12 @@ class ThingsBoardHttpSized {
     // Attribute API
 
     /// @brief Attempts to send attribute data with the given key and value of the given type
-    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
-    template<typename T1, typename T2>
-    inline bool sendAttributeData(T1 type, const char *key, T2 value) {
+    template<typename T>
+    inline bool sendAttributeData(const char *key, T value) {
       return sendKeyValue(key, value, false);
     }
 
@@ -325,7 +323,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeInt(const char *key, int value) {
-      return sendKeyValue(Int(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send boolean attribute data with the given key and value
@@ -333,7 +331,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeBool(const char *key, bool value) {
-      return sendKeyValue(Bool(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send float attribute data with the given key and value
@@ -341,7 +339,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeFloat(const char *key, float value) {
-      return sendKeyValue(Float(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send string attribute data with the given key and value
@@ -349,7 +347,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeString(const char *key, const char *value) {
-      return sendKeyValue(CString(), key, value, false);
+      return sendKeyValue(key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data
@@ -567,15 +565,14 @@ class ThingsBoardHttpSized {
     }
 
     /// @brief Sends single key-value attribute or telemetry data in a generic way
-    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param val Value of the key value pair we want to send
     /// @param telemetry Whetherr the aggregated data is telemetry (true) or attribut (false)
     /// @return Whetherr sending the data was successful or not
-    template<typename T1, typename T2>
-    inline bool sendKeyValue(T1 type, const char *key, T2 value, bool telemetry = true) {
-      const Telemetry t(type, key, value);
+    template<typename T>
+    inline bool sendKeyValue(const char *key, T value, bool telemetry = true) {
+      const Telemetry t(key, value);
       if (t.IsEmpty()) {
         // Message is ignored and not sent at all.
         return false;

--- a/src/ThingsBoardHttp.h
+++ b/src/ThingsBoardHttp.h
@@ -309,7 +309,7 @@ class ThingsBoardHttpSized {
     // Attribute API
 
     /// @brief Attempts to send attribute data with the given key and value of the given type
-    /// @tparam T2 Type of the passed value
+    /// @tparam T Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
@@ -565,7 +565,7 @@ class ThingsBoardHttpSized {
     }
 
     /// @brief Sends single key-value attribute or telemetry data in a generic way
-    /// @tparam T2 Type of the passed value
+    /// @tparam T Type of the passed value
     /// @param key Key of the key value pair we want to send
     /// @param val Value of the key value pair we want to send
     /// @param telemetry Whetherr the aggregated data is telemetry (true) or attribut (false)

--- a/src/ThingsBoardHttp.h
+++ b/src/ThingsBoardHttp.h
@@ -127,7 +127,7 @@ class ThingsBoardHttpSized {
 
     /// @brief Attempts to send telemetry data with the given key and value of the given type
     /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
@@ -165,7 +165,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendTelemetryString(const char *key, const char *value) {
-      return sendKeyValue(String(), key, value);
+      return sendKeyValue(CString(), key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data
@@ -311,7 +311,7 @@ class ThingsBoardHttpSized {
 
     /// @brief Attempts to send attribute data with the given key and value of the given type
     /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
@@ -349,7 +349,7 @@ class ThingsBoardHttpSized {
     /// @param value Value of the key value pair we want to send
     /// @return Whether sending the data was successful or not
     inline bool sendAttributeString(const char *key, const char *value) {
-      return sendKeyValue(String(), key, value, false);
+      return sendKeyValue(CString(), key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data
@@ -568,7 +568,7 @@ class ThingsBoardHttpSized {
 
     /// @brief Sends single key-value attribute or telemetry data in a generic way
     /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
-    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = CString, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param val Value of the key value pair we want to send
     /// @param telemetry Whetherr the aggregated data is telemetry (true) or attribut (false)

--- a/src/ThingsBoardHttp.h
+++ b/src/ThingsBoardHttp.h
@@ -125,36 +125,47 @@ class ThingsBoardHttpSized {
     //----------------------------------------------------------------------------
     // Telemetry API
 
+    /// @brief Attempts to send telemetry data with the given key and value of the given type
+    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @param key Key of the key value pair we want to send
+    /// @param value Value of the key value pair we want to send
+    /// @return Whether sending the data was successful or not
+    template<typename T1, typename T2>
+    inline bool sendTelemetryData(T1 type, const char *key, T2 value) {
+      return sendKeyValue(type, key, value);
+    }
+
     /// @brief Attempts to send integer telemetry data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
+    /// @return Whether sending the data was successful or not
     inline bool sendTelemetryInt(const char *key, int value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(Int(), key, value);
     }
 
     /// @brief Attempts to send boolean telemetry data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
+    /// @return Whether sending the data was successful or not
     inline bool sendTelemetryBool(const char *key, bool value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(Bool(), key, value);
     }
 
     /// @brief Attempts to send float telemetry data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
+    /// @return Whether sending the data was successful or not
     inline bool sendTelemetryFloat(const char *key, float value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(Float(), key, value);
     }
 
     /// @brief Attempts to send string telemetry data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
+    /// @return Whether sending the data was successful or not
     inline bool sendTelemetryString(const char *key, const char *value) {
-      return sendKeyValue(key, value);
+      return sendKeyValue(String(), key, value);
     }
 
     /// @brief Attempts to send aggregated telemetry data
@@ -298,36 +309,47 @@ class ThingsBoardHttpSized {
     //----------------------------------------------------------------------------
     // Attribute API
 
+    /// @brief Attempts to send attribute data with the given key and value of the given type
+    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
+    /// @param key Key of the key value pair we want to send
+    /// @param value Value of the key value pair we want to send
+    /// @return Whether sending the data was successful or not
+    template<typename T1, typename T2>
+    inline bool sendAttributeData(T1 type, const char *key, T2 value) {
+      return sendKeyValue(key, value, false);
+    }
+
     /// @brief Attempts to send integer attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
-    inline bool sendAttributeInt(const char *attrName, int value) {
-      return sendKeyValue(attrName, value, false);
+    /// @return Whether sending the data was successful or not
+    inline bool sendAttributeInt(const char *key, int value) {
+      return sendKeyValue(Int(), key, value, false);
     }
 
     /// @brief Attempts to send boolean attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
-    inline bool sendAttributeBool(const char *attrName, bool value) {
-      return sendKeyValue(attrName, value, false);
+    /// @return Whether sending the data was successful or not
+    inline bool sendAttributeBool(const char *key, bool value) {
+      return sendKeyValue(Bool(), key, value, false);
     }
 
     /// @brief Attempts to send float attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
-    inline bool sendAttributeFloat(const char *attrName, float value) {
-      return sendKeyValue(attrName, value, false);
+    /// @return Whether sending the data was successful or not
+    inline bool sendAttributeFloat(const char *key, float value) {
+      return sendKeyValue(Float(), key, value, false);
     }
 
     /// @brief Attempts to send string attribute data with the given key and value
     /// @param key Key of the key value pair we want to send
     /// @param value Value of the key value pair we want to send
-    /// @return Whetherr sending the data was successful or not
-    inline bool sendAttributeString(const char *attrName, const char *value) {
-      return sendKeyValue(attrName, value, false);
+    /// @return Whether sending the data was successful or not
+    inline bool sendAttributeString(const char *key, const char *value) {
+      return sendKeyValue(String(), key, value, false);
     }
 
     /// @brief Attempts to send aggregated attribute data
@@ -545,14 +567,15 @@ class ThingsBoardHttpSized {
     }
 
     /// @brief Sends single key-value attribute or telemetry data in a generic way
-    /// @tparam T Type of the passed value
+    /// @tparam T1 Type of the struct that is used to choose how the Telemtry object is constructed
+    /// @tparam T2 Type of the passed value should be equal to T1 (const char* = String, bool = Bool, int = Int, float = Float)
     /// @param key Key of the key value pair we want to send
     /// @param val Value of the key value pair we want to send
     /// @param telemetry Whetherr the aggregated data is telemetry (true) or attribut (false)
     /// @return Whetherr sending the data was successful or not
-    template<typename T>
-    inline bool sendKeyValue(const char *key, T value, bool telemetry = true) {
-      const Telemetry t(key, value);
+    template<typename T1, typename T2>
+    inline bool sendKeyValue(T1 type, const char *key, T2 value, bool telemetry = true) {
+      const Telemetry t(type, key, value);
       if (t.IsEmpty()) {
         // Message is ignored and not sent at all.
         return false;


### PR DESCRIPTION
The removal of `ARDUINO_JSON_NAMESPACE` seems good, because it is deprecated in the newest version. Furthermore I upgraded the library version to use the newest version of  `ArduinoJson` for PlattformIO users as well.

Mainly because it improves the overall ArduinoJson efficency, because the deprecation of the above mentioned feature allowed `ArduinoJson`  to move to a newer version of C++. Mainly C++ 11 instead of C++ 03. See [ArduinoJson News](https://arduinojson.org/news/2023/03/14/arduinojson-6-21-0/) for more information.

I also fixed the ambiguity with `float`, `int` and `bool` and removed the support for passing a `String` directly, because that caused ambiguity as well.

Furthermore the examples have been updated to fix the issues as well and now all examples compile successfully again, besides the issue of not enough memory footprint that existed previously already.

Would be nice if this could be merged.